### PR TITLE
Fix imports and C-style array warnings

### DIFF
--- a/deimos/clang/cxerrorcode.d
+++ b/deimos/clang/cxerrorcode.d
@@ -11,7 +11,7 @@
 |*                                                                            *|
 \*===----------------------------------------------------------------------===*/
 
-module clang.c.cxerrorcode;
+module deimos.clang.cxerrorcode;
 
 extern (C):
 

--- a/deimos/clang/cxstring.d
+++ b/deimos/clang/cxstring.d
@@ -11,7 +11,7 @@
 |*                                                                            *|
 \*===----------------------------------------------------------------------===*/
 
-module clang.c.cxstring;
+module deimos.clang.cxstring;
 
 extern (C):
 

--- a/deimos/clang/index.d
+++ b/deimos/clang/index.d
@@ -301,7 +301,7 @@ time_t clang_getFileTime(CXFile SFile);
  * across an indexing session.
  */
 struct CXFileUniqueID {
-  ulong data[3];
+  ulong[3] data;
 }
 
 /**
@@ -360,7 +360,7 @@ CXFile clang_getFile(CXTranslationUnit tu,
  * to map a source location to a particular file, line, and column.
  */
 struct CXSourceLocation {
-  const(void)* ptr_data[2];
+  const(void)*[2] ptr_data;
   uint int_data;
 }
 
@@ -371,7 +371,7 @@ struct CXSourceLocation {
  * starting and end locations from a source range, respectively.
  */
 struct CXSourceRange {
-  const(void)* ptr_data[2];
+  const(void)*[2] ptr_data;
   uint begin_int_data;
   uint end_int_data;
 }
@@ -2269,7 +2269,7 @@ enum CXCursorKind {
 struct CXCursor {
   CXCursorKind kind;
   int xdata;
-  const(void)* data[3];
+  const(void)*[3] data;
 }
 
 /**
@@ -2836,7 +2836,7 @@ enum CXCallingConv {
  */
 struct CXType {
   CXTypeKind kind;
-  void* data[2];
+  void*[2] data;
 }
 
 /**
@@ -3893,7 +3893,7 @@ enum CXTokenKind {
  * \brief Describes a single preprocessing token.
  */
 struct CXToken {
-  uint int_data[4];
+  uint[4] int_data;
   void* ptr_data;
 }
 
@@ -4952,7 +4952,7 @@ alias CXIdxClientASTFile = void*;
  * \brief Source location passed to index callbacks.
  */
 struct CXIdxLoc {
-  void *ptr_data[2];
+  void*[2] ptr_data;
   uint int_data;
 }
 

--- a/deimos/clang/index.d
+++ b/deimos/clang/index.d
@@ -13,14 +13,14 @@
 |*                                                                            *|
 \*===----------------------------------------------------------------------===*/
 
-module clang.c.index;
+module deimos.clang.index;
 
 import core.stdc.config;
 import core.stdc.time;
 
 
-import clang.c.cxerrorcode;
-import clang.c.cxstring;
+import deimos.clang.cxerrorcode;
+import deimos.clang.cxstring;
 
 extern (C):
 


### PR DESCRIPTION
Fixed imports pointing to incorrect paths; `clang.c.XYZ` becomes `deimos.clang.XYZ`
Fix compiler warnings for C-style arrays
